### PR TITLE
Fix flash size check with PF-build.sh

### DIFF
--- a/PF-build.sh
+++ b/PF-build.sh
@@ -76,6 +76,8 @@
 #                          $2 = multi language OR english only [ALL/EN_ONLY]
 #                          $3 = development status [GOLD/RC/BETA/ALPHA/DEVEL/DEBUG]
 #                          If one argument is wrong a list of valid one will be shown
+# 13 Mar 2019, 3d-gussner, MKbel updated the linux build enviromentto version 1.0.2 with an Fix maximum firmware flash size.
+#                          So did I
 
 
 ###Check if OSTYPE is supported
@@ -117,7 +119,7 @@ if ! type zip > /dev/null; then
 fi
 ###End prepare bash enviroment
 
-BUILD_ENV="1.0.1"
+BUILD_ENV="1.0.2"
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 # List few useful data


### PR DESCRIPTION
Hi @mkbel,

as i wrote in your pull request i implemented the changes made by you to the Win-PF-buil-env
see https://github.com/3d-gussner/PF-build-env/commit/3e85a66744d55183b7894ec1ab92ee10612afc45
and https://github.com/3d-gussner/PF-build-env/releases

As said: Compiling under Linux and Windows v.1.0.2 was successful using PF-build.sh.

